### PR TITLE
13 options to disable ldraw scaling and rotation

### DIFF
--- a/ConvertToLDraw/app.py
+++ b/ConvertToLDraw/app.py
@@ -264,8 +264,12 @@ class MainWindow(QMainWindow):
             scale = self.scale_input.value()
             multicolour = self.multicolour_check.checkState() == Qt.CheckState.Checked
             multi_object = self.multi_object_check.checkState() == Qt.CheckState.Checked
+            use_ldraw_scale = self.ldraw_scale_check.checkState() == Qt.CheckState.Checked
+            use_ldraw_rotation = self.ldraw_rotation_check.checkState() == Qt.CheckState.Checked
             try:
-                loaded_part = LdrawObject(filepath, scale=scale, multi_object=multi_object, multicolour=multicolour)
+                loaded_part = LdrawObject(filepath,
+                                          scale=scale, multi_object=multi_object, multicolour=multicolour,
+                                          use_ldraw_scale=use_ldraw_scale, use_ldraw_rotation=use_ldraw_rotation)
             except Exception:
                 QMessageBox.critical(self, "Failed to load file", "Not a 3D object or unsupported file format")
                 self.loaded_file_status_label.setText(f"Failed to Load: {filename}")
@@ -348,6 +352,8 @@ class MainWindow(QMainWindow):
         self.multicolour_check.setDisabled(value)
         self.multi_object_check.setDisabled(value)
         self.scale_input.setDisabled(value)
+        self.ldraw_rotation_check.setDisabled(value)
+        self.ldraw_scale_check.setDisabled(value)
         self.part_category_input.setDisabled(value)
         self.part_license_input.setDisabled(value)
         self.keywords_line.setReadOnly(value)
@@ -360,6 +366,8 @@ class MainWindow(QMainWindow):
         self.multi_object_check.setDisabled(False)
         self.scale_input.setDisabled(False)
         self.load_input_button.setDisabled(False)
+        self.ldraw_rotation_check.setDisabled(False)
+        self.ldraw_scale_check.setDisabled(False)
 
     def enable_reload(self):
         self.reload_preview = True

--- a/ConvertToLDraw/app.py
+++ b/ConvertToLDraw/app.py
@@ -79,7 +79,7 @@ class MainWindow(QMainWindow):
         # Enable Multicolour Check
         self.multicolour_check = QCheckBox()
         multicolour_label = QLabel("Multicolour ℹ️")
-        multicolour_label.setToolTip("If deactivated aLL objects are single color")
+        multicolour_label.setToolTip("If deactivated all objects are single colour")
         file_select_inputs.addRow(multicolour_label, self.multicolour_check)
         self.multicolour_check.setChecked(True)
 
@@ -87,8 +87,8 @@ class MainWindow(QMainWindow):
         self.multi_object_check = QCheckBox()
         multi_object_label = QLabel("Multiple Objects ℹ️")
         multi_object_label.setToolTip("If deactivated all submodels will be merged\n"
-                                      "With multicolor unique colors are applied before merging\n"
-                                      "(If the the file does not define colors)")
+                                      "With multicolour unique colours are applied before merging\n"
+                                      "(If the the file does not define colours)")
         file_select_inputs.addRow(multi_object_label, self.multi_object_check)
         self.multi_object_check.setChecked(True)
 

--- a/ConvertToLDraw/app.py
+++ b/ConvertToLDraw/app.py
@@ -102,6 +102,24 @@ class MainWindow(QMainWindow):
         scale_label.setToolTip("Factor used to scale the model")
         file_select_inputs.addRow(scale_label, self.scale_input)
 
+        # Enable LDraw Scale Check
+        self.ldraw_scale_check = QCheckBox()
+        ldraw_scale_label = QLabel("Use LDraw Scale ℹ️")
+        ldraw_scale_label.setToolTip("If deactivated LDraw Scale is not applied\n"
+                                     "This also disables automatic unit conversion prior to appliying LDraw Scale\n"
+                                     "You should only disable this if your model uses LDraw units")
+        file_select_inputs.addRow(ldraw_scale_label, self.ldraw_scale_check)
+        self.ldraw_scale_check.setChecked(True)
+
+        # Enable LDraw Rotation Check
+        self.ldraw_rotation_check = QCheckBox()
+        ldraw_rotation_label = QLabel("Use LDraw Axis ℹ️")
+        ldraw_rotation_label.setToolTip("If deactivated the model is not rotated\n"
+                                     "(In LDraws coordinate system -Y is up)\n"
+                                     "You should only disable this if your model uses LDraw axis")
+        file_select_inputs.addRow(ldraw_rotation_label, self.ldraw_rotation_check)
+        self.ldraw_rotation_check.setChecked(True)
+
         # Reload Button
         self.reload_button = QPushButton("Reload Model")
         self.reload_button.setIcon(QIcon(os.path.join(basedir, "icons", "reload-icon.svg")))

--- a/ConvertToLDraw/app.py
+++ b/ConvertToLDraw/app.py
@@ -56,13 +56,17 @@ class MainWindow(QMainWindow):
         top_layout = QHBoxLayout()
 
     # File Selection Area:
-        file_select_area = QGroupBox("File Selection")
-        file_select_inputs = QFormLayout()
-        file_select_area.setLayout(file_select_inputs)
+        file_select_area = QVBoxLayout()
+        load_file_area = QGroupBox("Load File")
+        load_file_inputs = QFormLayout()
+        load_file_area.setLayout(load_file_inputs)
+        save_file_area = QGroupBox("Save File")
+        save_file_inputs = QFormLayout()
+        save_file_area.setLayout(save_file_inputs)
 
-        # Input File Selection
+    # Input File Selection
         input_label = QLabel("Input File")
-        file_select_inputs.addRow(input_label)
+        load_file_inputs.addRow(input_label)
         input_layout = QHBoxLayout()
 
         self.input_file_line = QLineEdit()
@@ -74,13 +78,13 @@ class MainWindow(QMainWindow):
         input_layout.addWidget(self.load_input_button)
         self.load_input_button.clicked.connect(self.load_file)
 
-        file_select_inputs.addRow(input_layout)
+        load_file_inputs.addRow(input_layout)
 
         # Enable Multicolour Check
         self.multicolour_check = QCheckBox()
         multicolour_label = QLabel("Multicolour ℹ️")
         multicolour_label.setToolTip("If deactivated all objects are single colour")
-        file_select_inputs.addRow(multicolour_label, self.multicolour_check)
+        load_file_inputs.addRow(multicolour_label, self.multicolour_check)
         self.multicolour_check.setChecked(True)
 
         # Enable Multi Objects Check
@@ -89,7 +93,7 @@ class MainWindow(QMainWindow):
         multi_object_label.setToolTip("If deactivated all submodels will be merged\n"
                                       "With multicolour unique colours are applied before merging\n"
                                       "(If the the file does not define colours)")
-        file_select_inputs.addRow(multi_object_label, self.multi_object_check)
+        load_file_inputs.addRow(multi_object_label, self.multi_object_check)
         self.multi_object_check.setChecked(True)
 
         # Set Scale
@@ -100,7 +104,7 @@ class MainWindow(QMainWindow):
         self.scale_input.setDecimals(3)
         scale_label = QLabel("Scale ℹ️")
         scale_label.setToolTip("Factor used to scale the model")
-        file_select_inputs.addRow(scale_label, self.scale_input)
+        load_file_inputs.addRow(scale_label, self.scale_input)
 
         # Enable LDraw Scale Check
         self.ldraw_scale_check = QCheckBox()
@@ -108,7 +112,7 @@ class MainWindow(QMainWindow):
         ldraw_scale_label.setToolTip("If deactivated LDraw Scale is not applied\n"
                                      "This also disables automatic unit conversion prior to appliying LDraw Scale\n"
                                      "You should only disable this if your model uses LDraw units")
-        file_select_inputs.addRow(ldraw_scale_label, self.ldraw_scale_check)
+        load_file_inputs.addRow(ldraw_scale_label, self.ldraw_scale_check)
         self.ldraw_scale_check.setChecked(True)
 
         # Enable LDraw Rotation Check
@@ -117,20 +121,20 @@ class MainWindow(QMainWindow):
         ldraw_rotation_label.setToolTip("If deactivated the model is not rotated\n"
                                      "(In LDraws coordinate system -Y is up)\n"
                                      "You should only disable this if your model uses LDraw axis")
-        file_select_inputs.addRow(ldraw_rotation_label, self.ldraw_rotation_check)
+        load_file_inputs.addRow(ldraw_rotation_label, self.ldraw_rotation_check)
         self.ldraw_rotation_check.setChecked(True)
 
         # Reload Button
         self.reload_button = QPushButton("Reload Model")
         self.reload_button.setIcon(QIcon(os.path.join(basedir, "icons", "reload-icon.svg")))
         self.reload_button.clicked.connect(lambda a: self.load_file(True))
-        file_select_inputs.addRow(self.reload_button)
+        load_file_inputs.addRow(self.reload_button)
 
-        # Output File Selection
+    # Output File Selection
         output_label = QLabel("Output File ℹ️")
         output_label.setToolTip("Place where the Main File is saved.\n"
                                 "Subparts are saved in 's' subdirectory located in the same directory")
-        file_select_inputs.addRow(output_label)
+        save_file_inputs.addRow(output_label)
         output_layout = QHBoxLayout()
 
         self.output_file_line = QLineEdit()
@@ -142,7 +146,7 @@ class MainWindow(QMainWindow):
         output_layout.addWidget(self.select_output_button)
         self.select_output_button.clicked.connect(self.select_output_file)
 
-        file_select_inputs.addRow(output_layout)
+        save_file_inputs.addRow(output_layout)
 
     # Part Settings Area:
         part_settings_area = QGroupBox("Parent Part Settings")
@@ -216,13 +220,15 @@ class MainWindow(QMainWindow):
 
     # Add Elements to Main Layout
         top_layout.addWidget(part_settings_area)
-        top_layout.addWidget(file_select_area)
+        file_select_area.addWidget(load_file_area)
+        file_select_area.addWidget(save_file_area)
+        top_layout.addLayout(file_select_area)
         main_settings_widget = QWidget()
         main_settings_widget.setLayout(top_layout)
         self.settings_tabs.addTab(main_settings_widget, "Main Part Settings")
 
         self.main_layout.addWidget(self.settings_tabs)
-        file_select_inputs.addRow(self.convert_button)
+        save_file_inputs.addRow(self.convert_button)
 
         self.settings_tabs.addTab(subpart_area, "Subpart and Colour Settings")
         self.settings_tabs.addTab(self.preview_panel, "Part Preview")

--- a/ConvertToLDraw/brick_data/ldrawObject.py
+++ b/ConvertToLDraw/brick_data/ldrawObject.py
@@ -75,12 +75,16 @@ class LdrawObject:
         if use_ldraw_rotation:
             # LDraw co-ordinate system is right-handed where -Y is "up"
             # For this reason the entire scene is rotated by 90° around the X-axis
-            scene.apply_transform([
+            scene = scene.apply_transform([
                 [1, 0, 0, 0],
                 [0, 0, -1, 0],
                 [0, 1, 0, 0],
                 [0, 0, 0, 1]
             ])
+            if len(scene.geometry) == 1 and not use_ldraw_scale and scale == 1:
+                # "baking" rotation in case only one geometry exist
+                # not applied if any scaling is used as it also "bakes" the scene
+                scene = trimesh.scene.scene.Scene(scene.to_mesh())
 
         if scene.units not in ["mm", "millimeter", None] and use_ldraw_scale:
             scene = scene.convert_units("millimeter")

--- a/ConvertToLDraw/brick_data/ldrawObject.py
+++ b/ConvertToLDraw/brick_data/ldrawObject.py
@@ -82,7 +82,7 @@ class LdrawObject:
                 [0, 0, 0, 1]
             ])
 
-        if scene.units not in ["mm", "millimeter", None]:
+        if scene.units not in ["mm", "millimeter", None] and use_ldraw_scale:
             scene = scene.convert_units("millimeter")
 
         if scale != 1:

--- a/ConvertToLDraw/brick_data/ldrawObject.py
+++ b/ConvertToLDraw/brick_data/ldrawObject.py
@@ -14,9 +14,10 @@ class LdrawObject:
     def __init__(self, filepath: str,
                  name="", bricklinknumber="", author="", category="", keywords=None,
                  part_license=None,
-                 scale=1, multi_object=True, multicolour=True):
+                 scale=1, multi_object=True, multicolour=True,
+                 use_ldraw_scale=True, use_ldraw_rotation=True):
         self.cached_colour_definitions = OrderedDict()
-        self.__load_scene(filepath, scale, multi_object, multicolour)
+        self.__load_scene(filepath, scale, multi_object, multicolour, use_ldraw_scale, use_ldraw_rotation)
 
         self.name = name
         self.bricklinknumber = bricklinknumber
@@ -25,7 +26,8 @@ class LdrawObject:
         self.keywords = keywords
         self.part_license = part_license
 
-    def __load_scene(self, filepath, scale=1, multi_object=True, multicolour=True):
+    def __load_scene(self, filepath, scale=1, multi_object=True, multicolour=True,
+                     use_ldraw_scale=True, use_ldraw_rotation=True):
         _, file_extension = os.path.splitext(filepath)
 
         scene = trimesh.load_scene(filepath)
@@ -70,14 +72,15 @@ class LdrawObject:
 
             scene = trimesh.scene.scene.Scene(scene.to_mesh())
 
-        # LDraw co-ordinate system is right-handed where -Y is "up"
-        # For this reason the entire scene is rotated by 90° around the X-axis
-        scene.apply_transform([
-            [1, 0, 0, 0],
-            [0, 0, -1, 0],
-            [0, 1, 0, 0],
-            [0, 0, 0, 1]
-        ])
+        if use_ldraw_rotation:
+            # LDraw co-ordinate system is right-handed where -Y is "up"
+            # For this reason the entire scene is rotated by 90° around the X-axis
+            scene.apply_transform([
+                [1, 0, 0, 0],
+                [0, 0, -1, 0],
+                [0, 1, 0, 0],
+                [0, 0, 0, 1]
+            ])
 
         if scene.units not in ["mm", "millimeter", None]:
             scene = scene.convert_units("millimeter")
@@ -86,8 +89,9 @@ class LdrawObject:
             scene = scene.scaled(scale)
         self.size = scene.extents
 
-        # Convert to LDraw Units
-        scene = scene.scaled(2.5)
+        if use_ldraw_scale:
+            # Convert to LDraw Units
+            scene = scene.scaled(2.5)
 
         self.subparts = OrderedDict()
 


### PR DESCRIPTION
-added Option to disable LDraw Scaling and/or Rotation as descriped in #13 
-split "File Selection" area into "Save File" and "Load File", to improve the layout